### PR TITLE
Feature: Package value

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -16,4 +16,5 @@ REDIS_URL=string
 SENDGRID_API_KEY=string
 GOOGLE_API_KEY=string
 SLACK_ONBOARDING_CHANNEL_HOOK=string
+SLACK_DISPATCH_CHANNEL_HOOK=string
     "prestart": "npm run migrate:undo && npm run migrate",

--- a/server/api/v1/controllers/package.controller.js
+++ b/server/api/v1/controllers/package.controller.js
@@ -53,7 +53,7 @@ class Package {
   static async request_dispatch(req, res) {
     const { user } = req.session;
     let { type } = req.params;
-    const { weight, delivery_price, distance, ...data } = req.body;
+    const { weight, delivery_price, distance, value, ...data } = req.body;
     if (type.length <= 5) {
       type = `${type}-state`;
     }
@@ -131,6 +131,7 @@ class Package {
          type_of_dispatch: type,
          customer_id: user.id,
          weight,
+         value,
          distance,
          delivery_price,
          package_id,
@@ -525,6 +526,7 @@ class Package {
         _package.type_of_dispatch,
         new_weight,
         _package.distance,
+        _package.value
       );
       if (!new_delivery_price) {
         return res.status(400).json({
@@ -2290,7 +2292,7 @@ class Package {
             try {
               const distance_in_km = result.rows[0].elements[0].distance.text;
               const distance = Math.ceil(Number(distance_in_km.split(' ')[0].replace(',', '')));
-              const delivery_price = calc_delivery_price(type, data.weight, distance);
+              const delivery_price = calc_delivery_price(type, data.weight, distance, data.value);
               if (!delivery_price) {
                 return res.status(400).json({
                   status: 400,
@@ -2467,7 +2469,7 @@ class Package {
             try { 
               const distance_in_km = result.rows[0].elements[0].distance.text;
               const distance = Math.ceil(Number(distance_in_km.split(' ')[0].replace(',', '')));
-              const delivery_price = calc_delivery_price(type, data.weight, distance);
+              const delivery_price = calc_delivery_price(type, data.weight, distance, data.value);
               if (!delivery_price) {
                 return res.status(400).json({
                   status: 400,

--- a/server/api/v1/helpers/calc.price.js
+++ b/server/api/v1/helpers/calc.price.js
@@ -1,10 +1,11 @@
 /* eslint-disable camelcase */
 import weight_range from './weight.data';
+import value_range from './value.data';
 import { config } from 'dotenv';
 
 config();
 
-function calc_delivery_price(type, weight, distance) {
+function calc_delivery_price(type, weight, distance, value) {
   let base_price;
   if (type === 'intra-state') {
     base_price = process.env.KOOGAH_INTRA_STATE_DISPATCH_BASE_FEE;
@@ -16,11 +17,12 @@ function calc_delivery_price(type, weight, distance) {
     base_price = process.env.KOOGAH_INTERNATIONAL_DISPATCH_BASE_FEE;
   }
   const weight_value = weight_range[weight];
+  const package_value = value_range[value];
   const sms_charge = 50;
   const transfer_charge = 10;
   const price_slash_list = ['0-5', '6-10','11-15']
   if (!weight_range) return false;
-  var net_price = (weight_value * distance) + Number(base_price) + sms_charge + transfer_charge;
+  var net_price = ((weight_value * distance) + Number(base_price) + sms_charge + transfer_charge) * package_value;
   if (Number(distance) > 50) {
     if (type === 'intra-state') {
       if (net_price >= 15000 && price_slash_list.includes(weight)) {

--- a/server/api/v1/helpers/slack.js
+++ b/server/api/v1/helpers/slack.js
@@ -113,7 +113,7 @@ export const sendNewPackageNotification = function sendNewPackageNotification(pa
       "type": "section",
       "text": {
         "type": "mrkdwn",
-        "text": "• Package Id: `" + package_detail.package_id + "` \n• Description: `" + package_detail.description + "`\n• Weight: `" + package_detail.weight + "`"
+        "text": "• Package Id: `" + package_detail.package_id + "` \n• Description: `" + package_detail.description + "`\n• Weight: `" + package_detail.weight + "`\n• Value: `" + package_detail.value + "`\n• Price: `" + package_detail.delivery_price + "`"
       }
     },
     {

--- a/server/api/v1/helpers/value.data.js
+++ b/server/api/v1/helpers/value.data.js
@@ -1,0 +1,10 @@
+/* eslint-disable camelcase */
+const value_range = {
+  '0-999': 1,
+  '1000-9999': 2,
+  '10000-99999': 3,
+  '100000-999999': 4,
+  '1000000': 5
+};
+
+export default value_range;

--- a/server/database/migrations/20210723074833-modify_packages_add_value_column.js
+++ b/server/database/migrations/20210723074833-modify_packages_add_value_column.js
@@ -1,0 +1,23 @@
+'use strict';
+
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return queryInterface.describeTable('Packages').then(tableDefinition => {
+      if (!tableDefinition['value']){
+        return queryInterface.addColumn('Packages', 'value', {
+          type: Sequelize.STRING,
+          allowNull: true,
+        });
+      } else {
+        return Promise.resolve(true);
+      }
+   });
+  },
+
+  down: (queryInterface, Sequelize) => {
+    return queryInterface.removeColumn(
+      'Packages',
+      'value',
+    );
+  }
+};

--- a/server/database/models/packages.js
+++ b/server/database/models/packages.js
@@ -140,6 +140,10 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.STRING,
       allowNull: false
     },
+    value: {
+      type: DataTypes.STRING,
+      allowNull: true
+    }
   },
   {
     underscored: true,

--- a/server/middlewares/schema.js
+++ b/server/middlewares/schema.js
@@ -105,6 +105,7 @@ class Schema {
   static edit_package_schema() {
     return Joi.object({
       weight: Joi.string(),
+      value: Joi.string().valid('0-999', '1000-9999', '10000-99999', '100000-999999', '1000000'),
       description: Joi.string(),
       payment_mode: Joi.string().valid('virtual_balance', 'koogah_coin'),
       from_country: Joi.string(),
@@ -135,6 +136,7 @@ class Schema {
   static intra_package_schema() {
     return Joi.object({
       weight: Joi.string().required(),
+      value: Joi.string().valid('0-999', '1000-9999', '10000-99999', '100000-999999', '1000000'),
       description: Joi.string().required(),
       payment_mode: Joi.string().valid('virtual_balance', 'koogah_coin').required(),
       from_state: Joi.string().required(),
@@ -161,6 +163,7 @@ class Schema {
   static inter_package_schema() {
     return Joi.object({
       weight: Joi.string().required(),
+      value: Joi.string().valid('0-999', '1000-9999', '10000-99999', '100000-999999', '1000000'),
       description: Joi.string().required(),
       payment_mode: Joi.string().valid('virtual_balance', 'koogah_coin').required(),
       from_state: Joi.string().required(),
@@ -187,6 +190,7 @@ class Schema {
   static international_package_schema() {
     return Joi.object({
       weight: Joi.string().required(),
+      value: Joi.string().valid('0-999', '1000-9999', '10000-99999', '100000-999999', '1000000'),
       description: Joi.string().required(),
       payment_mode: Joi.string().valid('virtual_balance', 'koogah_coin').required(),
       from_country: Joi.string().required(),


### PR DESCRIPTION
### What does this PR do?
Implements package value functionality

### Description of Task proposed in this pull request
- Add new column `value` to packages table via migration
- Modify models to include the `value` column
- Modify the `calculate price` function  definition to take `value` as an argument
- Modify every instance where `calculate price` function was called to send the value parameter
- Support `value` to come in via params for `request_dispatch`, `edit_package` and `get_estimate` endpoints
- Schema validation for the value field
- Modify slack notification for new dispatch to request to include value and price

### Any background context you want to add (Operations Impact)?
The field `value` was made to allowNull because of the previous records, we can agree to have a default value and change it to `allowNull: false`.